### PR TITLE
Fixed encoding in POD (RT#85212)

### DIFF
--- a/lib/MusicBrainz/DiscID.pm
+++ b/lib/MusicBrainz/DiscID.pm
@@ -156,7 +156,7 @@ Returns a device string for the default device for this platform.
 Construct a new DiscID object.
 
 As an optional argument the name of the device to read the ID from may 
-be given. If you donÔt specify a device here you can later read the ID with 
+be given. If you don't specify a device here you can later read the ID with 
 the read method.
 
 =item $discid->error_msg()


### PR DESCRIPTION
This pull request applies Gregor Herrmann's patch from https://rt.cpan.org/Public/Bug/Display.html?id=85212 to your MusicBrainz::DiscID module. The patch fixes an encoding problem that breaks the test suite under recent Perl versions.
