### PR TITLE
Fixed stack corruption in discid_put (RT#98179)

### DIFF
--- a/lib/MusicBrainz/DiscID.xs
+++ b/lib/MusicBrainz/DiscID.xs
@@ -124,12 +124,13 @@ discid_put( disc, first_track, sectors, offsets ... )
   DiscId *disc
   int first_track
   int sectors
+  int n_items = items;
   PREINIT:
 	  int i, last_track, offsets[100];
   CODE:
-	  for (i=0;i<100;i++);
-	      offsets[i] = 0;
-    for (i=3; i<items; i++) {
+    memset(offsets, 0, sizeof(offsets));
+    if (items > 102 ) n_items = 102;  // rely on discid_put to return error
+    for (i=3; i<n_items; i++) {
         offsets[i-2] = (int)SvIV(ST(i));
     }
     offsets[0] = sectors;

--- a/t/10discid.t
+++ b/t/10discid.t
@@ -5,7 +5,7 @@ use strict;
 use Test::More;
 
 # use a BEGIN block so we print our plan before modules are loaded
-BEGIN { plan tests => 54 }
+BEGIN { plan tests => 56 }
 
 # load modules
 use MusicBrainz::DiscID;
@@ -16,6 +16,9 @@ my $disc = new MusicBrainz::DiscID();
 ok( $disc );
 is(ref $disc, 'MusicBrainz::DiscID');
 
+ok( !$disc->put( 1, 140, 1 .. 100 ) );
+
+like( $disc->error_msg, qr{Illegal (parameters|track limits)} );
 
 ok( $disc->put( 1, 303602,
                 150, 9700, 25887, 39297, 53795, 63735, 77517, 94877, 107270,


### PR DESCRIPTION
This pull request applies Damyan Ivanov's patch from https://rt.cpan.org/Public/Bug/Display.html?id=98179. I've changed Damyan's test case so that it works with libdiscid 0.2.2 and 0.6.1. Tested on Debian Jessie and Slackware-current with libdiscid 0.6.1 and Debian Wheezy with libdiscid 0.2.2.
